### PR TITLE
Fix compile without boeffla_wl_blocker

### DIFF
--- a/drivers/base/power/wakeup.c
+++ b/drivers/base/power/wakeup.c
@@ -42,9 +42,9 @@ char list_wl_search[LENGTH_LIST_WL_SEARCH] = {0};
 bool wl_blocker_active = false;
 bool wl_blocker_debug = false;
 
-static void wakeup_source_deactivate(struct wakeup_source *ws);
 #endif
 
+static void wakeup_source_deactivate(struct wakeup_source *ws);
 
 /*
  * If set, the suspend/hibernate code will abort transitions to a sleep state


### PR DESCRIPTION
- wakeup_source_deactivate prototype should always be defined

Change-Id: I16d3c9b4739bbac4ed22dda366cf1e9f25c9446f